### PR TITLE
Enable multi-config support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.retry
 */__pycache__
 *.pyc
+molecule-venv

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ cwa_config_dir: /opt/aws/amazon-cloudwatch-agent/etc
 ```
 The directory into which the agent config file will be placed.
 
+TODO: fix this below
 ```
 cwa_config_map:
   metrics:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,9 +9,9 @@ cwa_mode: ec2
 cwa_logfile: /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
 
 cwa_config_dir: /opt/aws/amazon-cloudwatch-agent/etc
-cwa_config_map:
-  metrics:
-    metrics_collected:
-      mem:
-        measurement:
-          - name: mem_used_percent
+cwa_config_maps:
+  - metrics:
+      metrics_collected:
+        mem:
+          measurement:
+            - name: mem_used_percent

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,17 +1,15 @@
 ---
 - name: Ensure json config file is in place and is valid
   template:
-    src: "{{ item }}.j2"
-    dest: "{{ cwa_config_dir }}/{{ item }}"
+    src: "amazon-cloudwatch-agent.json.j2"
+    dest: "{{ cwa_config_dir }}/amazon-cloudwatch-agent.d/fragment_{{ cfg_index }}"
     owner: root
     group: root
     mode: 0644
-    validate: |
-      /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl
-      -a fetch-config -c file:%s -m {{ cwa_mode }}
   notify: restart cwa
-  with_items:
-    - amazon-cloudwatch-agent.json
+  loop: "{{cwa_config_maps}}"
+  loop_control:
+    index_var: cfg_index
 
 - name: Ensure service is started and enabled
   service:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -2,14 +2,12 @@
 - name: Ensure json config file is in place and is valid
   template:
     src: "amazon-cloudwatch-agent.json.j2"
-    dest: "{{ cwa_config_dir }}/amazon-cloudwatch-agent.d/fragment_{{ cfg_index }}"
+    dest: "{{ cwa_config_dir }}/amazon-cloudwatch-agent.d/fragment_{{ item | hash('sha1') }}"
     owner: root
     group: root
     mode: 0644
   notify: restart cwa
   loop: "{{cwa_config_maps}}"
-  loop_control:
-    index_var: cfg_index
 
 - name: Ensure service is started and enabled
   service:

--- a/templates/amazon-cloudwatch-agent.json.j2
+++ b/templates/amazon-cloudwatch-agent.json.j2
@@ -1,1 +1,1 @@
-{{ cwa_config_map | to_nice_json(indent=2) }}
+{{ item | to_nice_json(indent=2) }}


### PR DESCRIPTION
This PR adds support to multiple fragments of configuration to handle different configurations so it can be extended easily by adding more entries to the map list instead of using one monolithic map. CWA takes care of merging the different fragment into one config (and fails to start if something is not right)